### PR TITLE
Update architecture.html

### DIFF
--- a/architecture.html
+++ b/architecture.html
@@ -21,7 +21,7 @@ citation: true
 
 <p>At a deeper level, seen typically after purchase, a user will find the gameplay accessed through direct interaction with the device. The
   game is standardized from device to device giving users a common experience through play. The hardware, found at the deepest level by literally
-  breaking open the device and often only accessed by particularly types of fans (curious-types, tinkerers, and amateur engineers and programmers)
+  breaking open the device and often only accessed by particular types of fans (curious-types, tinkerers, and amateur engineers and programmers)
   is rather simple and an ideal place for the young and curious to begin exploring the inner-workings of tech devices.</p>
 
 <p>Above are links that dive a little deeper into each layer and below are a series of diagrams that visually break each layer down.</p></p>


### PR DESCRIPTION
Fixed typo: "The hardware, found at the deepest level by literally breaking open the device and often only accessed by **particularly** types of fans (curious-types, tinkerers, and amateur engineers and programmers) is rather simple and an ideal place for the young and curious to begin exploring the inner-workings of tech devices."